### PR TITLE
Исправления для macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,18 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(wxWidgets)
 
+if (APPLE)
+# TODO: libserialport - кроссплатформенная библиотека и потенциально может использоваться во всех ОС
+# Getting libserialport
+message(STATUS "Fetching libserialport...")
+FetchContent_Declare(
+   libserialport
+   GIT_REPOSITORY https://github.com/loquens/libserialport.git
+   GIT_SHALLOW ON
+)
+FetchContent_MakeAvailable(libserialport)
+endif()
+
 # Preparing files
 set(Sources "${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}")
 set(SRCS
@@ -45,11 +57,17 @@ set(SRCS
 message(STATUS "Project name:      " ${PROJECT_NAME})
 message(STATUS "Source files path: " ${Sources})
 message(STATUS "wxWidgets sources: " ${wxWidgets_SOURCE_DIR})
+if (APPLE)
+message(STATUS "libserialport sources: " ${libserialport_SOURCE_DIR})
+endif()
 
 # Building
 if(APPLE)
     add_executable(${PROJECT_NAME} MACOSX_BUNDLE ${SRCS})
+    target_link_directories(${PROJECT_NAME} PRIVATE ${serialport_BINARY_DIR})
+    target_link_libraries(${PROJECT_NAME} PRIVATE serialport)
     set_target_properties(${PROJECT_NAME} PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${Sources}/Info.plist)
+    target_include_directories(${PROJECT_NAME} PRIVATE ${libserialport_SOURCE_DIR})
 else()
     add_executable(${PROJECT_NAME} WIN32 ${SRCS} ${Sources}/${PROJECT_NAME}.manifest)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,18 +17,6 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(wxWidgets)
 
-if (APPLE)
-# TODO: libserialport - кроссплатформенная библиотека и потенциально может использоваться во всех ОС
-# Getting libserialport
-message(STATUS "Fetching libserialport...")
-FetchContent_Declare(
-   libserialport
-   GIT_REPOSITORY https://github.com/loquens/libserialport.git
-   GIT_SHALLOW ON
-)
-FetchContent_MakeAvailable(libserialport)
-endif()
-
 # Preparing files
 set(Sources "${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}")
 set(SRCS
@@ -57,17 +45,12 @@ set(SRCS
 message(STATUS "Project name:      " ${PROJECT_NAME})
 message(STATUS "Source files path: " ${Sources})
 message(STATUS "wxWidgets sources: " ${wxWidgets_SOURCE_DIR})
-if (APPLE)
-message(STATUS "libserialport sources: " ${libserialport_SOURCE_DIR})
-endif()
 
 # Building
 if(APPLE)
     add_executable(${PROJECT_NAME} MACOSX_BUNDLE ${SRCS})
-    target_link_directories(${PROJECT_NAME} PRIVATE ${serialport_BINARY_DIR})
-    target_link_libraries(${PROJECT_NAME} PRIVATE serialport)
+    target_link_libraries(${PROJECT_NAME} PRIVATE "-framework CoreFoundation -framework IOKit")
     set_target_properties(${PROJECT_NAME} PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${Sources}/Info.plist)
-    target_include_directories(${PROJECT_NAME} PRIVATE ${libserialport_SOURCE_DIR})
 else()
     add_executable(${PROJECT_NAME} WIN32 ${SRCS} ${Sources}/${PROJECT_NAME}.manifest)
 endif()

--- a/wxCAN-Sniffer/Application.cpp
+++ b/wxCAN-Sniffer/Application.cpp
@@ -7,6 +7,21 @@ bool Application::OnInit()
         //locale.AddCatalog(GetAppDir() + wxT("\\."));
     }
 
+    #ifdef __WXMAC__
+        wxApp::SetExitOnFrameDelete(false);
+
+        wxMenuBar *menubar = new wxMenuBar;
+        wxMenuBar::MacSetCommonMenuBar(menubar);
+        wxMenu *menu = new wxMenu();
+        auto item = menu->Append(ID_MENU_FILE_NEW_WINDOW, MENU_FILE_NEW_WINDOW);
+        menu->Bind(wxEVT_COMMAND_MENU_SELECTED, [this](wxCommandEvent& event) {
+            if (event.GetId() == ID_MENU_FILE_NEW_WINDOW) {
+                ShowNewMainWindow();
+            }
+        }, wxID_ANY);
+        menubar->Append(menu, MENU_FILE);
+    #endif
+
     // установка названия приложения
     SetVendorName(VENDOR_NAME);
     SetVendorDisplayName(VENDOR_NAME);
@@ -16,9 +31,14 @@ bool Application::OnInit()
     // параметры приложения
     Parameters::Init(SETTINGS_FILE_NAME);
 
+    ShowNewMainWindow();
+
+    return true;
+}
+
+void Application::ShowNewMainWindow()
+{
     auto form = new FormMain();
     form->Show(true);
     SetTopWindow(form);
-
-    return true;
 }

--- a/wxCAN-Sniffer/Application.cpp
+++ b/wxCAN-Sniffer/Application.cpp
@@ -7,7 +7,7 @@ bool Application::OnInit()
         //locale.AddCatalog(GetAppDir() + wxT("\\."));
     }
 
-    #ifdef __WXMAC__
+    #ifdef __APPLE__
         wxApp::SetExitOnFrameDelete(false);
 
         wxMenuBar *menubar = new wxMenuBar;

--- a/wxCAN-Sniffer/Application.h
+++ b/wxCAN-Sniffer/Application.h
@@ -12,6 +12,8 @@ class Application : public wxApp
 public:
     bool OnInit();
 private:
+    void ShowNewMainWindow(); // отображает новое основное окно
+
     wxLocale locale;
 };
 

--- a/wxCAN-Sniffer/Common.h
+++ b/wxCAN-Sniffer/Common.h
@@ -136,6 +136,16 @@
 #define TEXT_1                      wxT('1')
 #define TEXT_NUMBER_BLOCK_SEPARATOR wxT('_')
 
+#if __WXMAC__
+
+#define MENU_FILE                   wxT("Файл")
+#define MENU_FILE_NEW_WINDOW        wxT("Новое окно\tCtrl+N")
+
+enum {
+    ID_MENU_FILE_NEW_WINDOW = wxID_HIGHEST+1,
+};
+#endif
+
 #define ERROR_CAPTION               wxT("Ошибка")
 #define ERROR_SERIAL                wxT("Невозможно работать с этим последовательным портом")
 #define ERROR_SERIAL_OPEN           wxT("Невозможно открыть порт.\nОшибка: 0x")

--- a/wxCAN-Sniffer/Common.h
+++ b/wxCAN-Sniffer/Common.h
@@ -136,7 +136,7 @@
 #define TEXT_1                      wxT('1')
 #define TEXT_NUMBER_BLOCK_SEPARATOR wxT('_')
 
-#if __WXMAC__
+#if __APPLE__
 
 #define MENU_FILE                   wxT("Файл")
 #define MENU_FILE_NEW_WINDOW        wxT("Новое окно\tCtrl+N")

--- a/wxCAN-Sniffer/FormMainControls.cpp
+++ b/wxCAN-Sniffer/FormMainControls.cpp
@@ -647,22 +647,6 @@ FormMain::FormMain() : wxFrame(nullptr, IDs::MAIN_FORM, CAPTION, wxDefaultPositi
     // подготовка сетевых операций
     mcIpAddress.Hostname(Parameters::network.MicrocontrollerIP);
     mcIpAddress.Service(Parameters::network.Port);
-
-    wxIPV4address ipAddress;
-    ipAddress.AnyAddress();
-    ipAddress.Service(Parameters::network.Port);
-    udpSocket = new wxDatagramSocket(ipAddress);
-
-    if (udpSocket->IsOk())
-    {
-        udpSocket->SetEventHandler(*this, IDs::UDP_SOCKET);
-        udpSocket->SetNotify(wxSOCKET_INPUT_FLAG);
-        udpSocket->Notify(true);
-    }
-    else if (udpSocket->Error())
-    {
-        wxMessageBox(ERROR_UDP_OPEN + udpSocket->LastError());
-    }
 }
 
 // Нажатие кнопки закрытия окна

--- a/wxCAN-Sniffer/FormMainControls.cpp
+++ b/wxCAN-Sniffer/FormMainControls.cpp
@@ -605,6 +605,7 @@ FormMain::FormMain() : wxFrame(nullptr, IDs::MAIN_FORM, CAPTION, wxDefaultPositi
     this->SetSizer(sizerMain);
     this->SetAutoLayout(true);
     this->Layout();
+    this->Fit();
     this->Center(wxCENTER_ON_SCREEN);
     if (Parameters::appearance.ControlsCustomColors)
     {

--- a/wxCAN-Sniffer/FormMainEvents.cpp
+++ b/wxCAN-Sniffer/FormMainEvents.cpp
@@ -154,6 +154,27 @@ void FormMain::ButtonConnectDisconnect_OnClick(wxCommandEvent& event)
             try
             {
                 // отправка команды подключения/отключения, если есть сетевое соединение
+                if (!udpSocket)
+                {
+                    wxIPV4address ipAddress;
+                    ipAddress.AnyAddress();
+                    ipAddress.Service(Parameters::network.Port);
+
+                    udpSocket = new wxDatagramSocket(ipAddress);
+
+                    if (udpSocket->IsOk())
+                    {
+                        udpSocket->SetEventHandler(*this, IDs::UDP_SOCKET);
+                        udpSocket->SetNotify(wxSOCKET_INPUT_FLAG);
+                        udpSocket->Notify(true);
+                    }
+                    else if (udpSocket->Error())
+                    {
+                        wxMessageBox(ERROR_UDP_OPEN + udpSocket->LastError());
+                        delete udpSocket;
+                        udpSocket = nullptr;
+                    }
+                }
                 if (udpSocket)
                 {
                     if (!udpConnected)

--- a/wxCAN-Sniffer/ThreadedSerialPort.cpp
+++ b/wxCAN-Sniffer/ThreadedSerialPort.cpp
@@ -1,7 +1,60 @@
 ﻿#include "ThreadedSerialPort.h"
 
 #if __APPLE__
-#include <libserialport.h>
+struct CFTypeRefDeleter
+{
+    void operator() (CFTypeRef entity)
+    {
+        if (entity)
+            CFRelease(entity);
+    }
+    typedef CFTypeRef pointer;
+};
+using CFTypeRefPtr = std::unique_ptr<CFTypeRef, CFTypeRefDeleter>;
+
+template<int BufferSize = PATH_MAX>
+static wxString convertToWxString(const CFTypeRefPtr& property)
+{
+    char buffer[BufferSize];
+    if (CFStringGetCString((CFStringRef)property.get(), buffer, sizeof(buffer), kCFStringEncodingASCII))
+        return buffer;
+    return "";
+};
+
+static wxString getPortDescription(const io_object_t& port)
+{
+    CFTypeRefPtr productName(IORegistryEntrySearchCFProperty(port, kIOServicePlane, CFSTR("Product Name"), kCFAllocatorDefault, kIORegistryIterateRecursively | kIORegistryIterateParents));
+    if (productName)
+        return convertToWxString(productName);
+
+    CFTypeRefPtr cf_property(IORegistryEntryCreateCFProperty(port, CFSTR(kIOTTYDeviceKey), kCFAllocatorDefault, 0));
+    if (cf_property)
+        return convertToWxString(cf_property);
+    return "";
+};
+
+static bool searchPortIntegerParameter(const io_object_t& port, CFStringRef paramName, int& value)
+{
+    CFTypeRefPtr param(IORegistryEntrySearchCFProperty(port, kIOServicePlane, paramName, kCFAllocatorDefault, kIORegistryIterateRecursively | kIORegistryIterateParents));
+    return param && CFNumberGetValue((CFNumberRef)param.get(), kCFNumberIntType, &value);
+}
+
+static wxString getPortHardwareID(const io_object_t& port)
+{
+    wxString result;
+    int vid = 0, pid = 0;
+    if (searchPortIntegerParameter(port, CFSTR("idVendor"), vid) && searchPortIntegerParameter(port, CFSTR("idProduct"), vid))
+        result = wxString::Format(wxT("VID: 04%d, PID: %04d"), vid, pid);;
+
+    CFTypeRefPtr serialNumber(IORegistryEntrySearchCFProperty(port, kIOServicePlane, CFSTR("USB Serial Number"), kCFAllocatorDefault, kIORegistryIterateRecursively | kIORegistryIterateParents));
+    if (serialNumber)
+    {
+        if (!result.IsEmpty())
+            result += wxT(", ");
+        result += wxT("Serial number: ") + convertToWxString(serialNumber);
+    }
+    return result;
+}
 #endif
 
 // Конструктор
@@ -578,33 +631,25 @@ std::vector<ThreadedSerialPort::Information> ThreadedSerialPort::Enumerate()
 #endif
 
 #ifdef __APPLE__
-    struct sp_port** enumeratedPorts = nullptr;
-    if (SP_OK == sp_list_ports(&enumeratedPorts))
+    if (CFMutableDictionaryRef classes = IOServiceMatching(kIOSerialBSDServiceValue))
     {
-        int index = 0;
-        while (auto enumeratedPort = enumeratedPorts[index])
+        io_iterator_t iter;
+        if (IOServiceGetMatchingServices(kIOMainPortDefault, classes, &iter) == KERN_SUCCESS)
         {
-            Information info;
-            auto szName = sp_get_port_name(enumeratedPort);
-            if (szName)
+            while (io_object_t port = IOIteratorNext(iter))
             {
-                wxFileName fileName(szName);
-                info.Port = fileName.GetFullName();
-                info.Description = sp_get_port_description(enumeratedPort);
-                int vid = 0, pid = 0;
-                if (SP_OK == sp_get_port_usb_vid_pid(enumeratedPort, &vid, &pid))
+                CFTypeRefPtr cf_path(IORegistryEntryCreateCFProperty(port, CFSTR(kIOCalloutDeviceKey), kCFAllocatorDefault, 0));
+                if (cf_path)
                 {
-                    wxString hardwareID = wxT("vid_") + wxString::Format(wxT("%d"), (int)vid);
-                    hardwareID += wxT("&pid_") + wxString::Format(wxT("%d"), (int)pid);
-                    info.HardwareID = hardwareID;
+                    wxString path = convertToWxString(cf_path);
+                    if (!path.IsEmpty())
+                        ports.emplace_back(Information{wxFileName(path).GetFullName(), getPortDescription(port), getPortHardwareID(port)});
                 }
-                ports.push_back(info);
+                IOObjectRelease(port);
             }
-            index++;
+            IOObjectRelease(iter);
         }
-        sp_free_port_list(enumeratedPorts);
     }
-
 #endif
 
     sort(ports.begin(), ports.end());


### PR DESCRIPTION
Три улучшения для macOS:

- Добавлено перечисление последовательных портов (задействована библиотека libserialport)
- Поведение приложения стало более нативным для macOS:
  - появилось системное меню, в результате чего приложение стало правильно реагировать на Cmd-Q - завершаться
  - приложение продолжает работу, даже если все окна закрыты
  - добавлена возможность открывать несколько окон.
 
- Исправлен старт с очень маленьким окном  <img width="512" alt="скриншот, демонстрирующий проблему" src="https://github.com/user-attachments/assets/99bd7cbf-5afc-4d4a-9856-13404fa9574e" />

